### PR TITLE
MaxFileSize not working due to bytesWritten counter being reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ However, some applications are constrained to only application-side log rotation
 
 ## Usage
 ```
-go get github.com/easyCZ/logrotate
+go get github.com/Vykstorm/logrotate
 ```
 
 ```go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"time"
     
-    "github.com/easyCZ/logrotate"
+    "github.com/Vykstorm/logrotate"
 )
 
 func main() {
@@ -60,7 +60,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/easyCZ/logrotate"
+	"github.com/Vykstorm/logrotate"
 )
 
 func main() {
@@ -89,7 +89,7 @@ package main
 import (
 	"os"
 	log "github.com/sirupsen/logrus"
-	logrotate "github.com/easyCZ/logrotate"
+	logrotate "github.com/Vykstorm/logrotate"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/easyCZ/logrotate
+module github.com/Vykstorm/logrotate
 
 go 1.21
 

--- a/writer.go
+++ b/writer.go
@@ -166,7 +166,8 @@ func (w *Writer) flushCurrentFile() error {
 		return errors.Wrap(err, "failed to sync current log file")
 	}
 
-	w.bytesWritten = 0
+	// THIS breaks  FileMaxSize option
+	// w.bytesWritten = 0
 
 	return nil
 }


### PR DESCRIPTION
bytesWritten counter is being reset, thus ignoring log rotation using the max file size parameter.